### PR TITLE
Allow "->" arrows

### DIFF
--- a/lib/justify-self.js
+++ b/lib/justify-self.js
@@ -1,7 +1,7 @@
 module.exports = function getJustifySelf(zone) {
 
-	let leftIndicator  = zone.content.search(/[←<]/),
-	    rightIndicator = zone.content.search(/[→>]/);
+	let leftIndicator  = zone.content.search(/←|<-|</),
+	    rightIndicator = zone.content.search(/→|->|>/);
 
 	if (leftIndicator >= 0 && rightIndicator > leftIndicator)
 		return "stretch"


### PR DESCRIPTION
It'd be really nice to be able to use full ASCII arrows in grid-kiss. I actually thought that unicode arrows were the only available option until I tracked though the source code to make this PR, because the examples only use the unicode arrow and scrolling down would go against every moral bone in my body.

This works really well with ligature fonts such as [Fira Code](https://github.com/tonsky/FiraCode):

![Screenshot 2019-11-02 at 00 22 25](https://user-images.githubusercontent.com/29130152/68063199-06ab5180-fd07-11e9-9cd5-d6fa5c63a4c8.png)

Currently, the above syntax would give `justify-self: center` to an element of type `-.conversation-container-`.

This PR would allow ASCII arrows (`->` and `<-`) to be used instead of `>` and `<`.