### PR TITLE
Fix Text recognition is line based instead of string based #23

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -11,7 +11,7 @@ module.exports = function parse(decl, options) {
 }
 
 function getRows(str) {
-	return str.match(/".*"|'.*'/g).map(row => row.slice(1, row.length - 1));
+	return str.match(/".*?"|'.*?'/g).map(row => row.slice(1, row.length - 1));
 }
 
 function getCols({ rows }) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
 	"name": "postcss-grid-kiss",
-	"version": "3.0.0",
+	"version": "3.0.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"version": "3.0.0",
+			"version": "3.0.1",
 			"license": "MIT",
 			"dependencies": {
 				"browserslist": "^4.16.6",

--- a/test.js
+++ b/test.js
@@ -880,3 +880,22 @@ test("css vars", async t => {
 	t.is(output["div"]["grid-template-rows"], `var(--fooh) 1fr`)
 	t.is(output["div"]["grid-template-columns"], `var(--barw) var(--quxw)`)
 })
+
+test("minimization", async t => {
+	let unminimized = await process(
+		`div {
+		grid-kiss:
+		   "+--------------------------+ --   "
+		   "| header                   | 48px "
+		   "+--------------------------+ --   "
+		   "+--------+ +---------------+ --   "
+		   "| aside  | | main          | auto "
+		   "+--------+ +---------------+ --   "
+		   "| 48px   | | auto          |      ";
+}`, { fallback:false })
+	let minimized = await process(
+		`div {
+			grid-kiss: "+--------------------------+ --   " "| header                   | 48px " "+--------------------------+ --   " "+--------+ +---------------+ --   " "| aside  | | main          | auto " "+--------+ +---------------+ --   " "| 48px   | | auto          |      ";
+	}`, { fallback:false })
+	t.deepEqual(unminimized, minimized)
+})


### PR DESCRIPTION
Fix #23 

Made getRows regex ungreedy to match correctly rows :

from:
```
/".*"|'.*'/g
```
to:
```
/".*?"|'.*?'/g
```
alternate syntax:
to:
```
/"[^"]*"|'[^']*'/g
```